### PR TITLE
Add Python version to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
   - apple
   - defaults
 dependencies:
+  - python=3.9
   - pip:
       - absl-py==1.4.0
       - aiohttp==3.8.3


### PR DESCRIPTION
Hi, I was the last one in your workshop on Thursday. At the end you gave me the advice to create a Conda environment with environment.yaml, which didn't work with a recent Python version. I just wanted to let you know that adding the Python version fixed the environment and I was then able to run the example on my M1 Mac.

I hope this helps in case you want to use the example next time. Thanks for the great workshop :)